### PR TITLE
updated to 2025 LevelPlay

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-ironSource copyright © 2021 ironSource Ltd.
+LevelPlay copyright © 2025 LevelPlay Ltd.
 
 This software is subject to, and made available under, the Unity Advertising Terms of Service (available at https://unity.com/legal/one-operate-services-terms-of-service), and is a "Service Asset" as defined therein.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-LevelPlay copyright © 2025 LevelPlay Ltd.
+LevelPlay copyright © 2021-2025 Unity Technologies.
 
 This software is subject to, and made available under, the Unity Advertising Terms of Service (available at https://unity.com/legal/one-operate-services-terms-of-service), and is a "Service Asset" as defined therein.
 

--- a/iOS/Objective C/LevelPlayDemo/AppDelegate.h
+++ b/iOS/Objective C/LevelPlayDemo/AppDelegate.h
@@ -2,7 +2,7 @@
 //  AppDelegate.h
 //  LevelPlayDemo
 //
-//  Copyright © 2024 ironSource Mobile Ltd. All rights reserved.
+//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/iOS/Objective C/LevelPlayDemo/AppDelegate.h
+++ b/iOS/Objective C/LevelPlayDemo/AppDelegate.h
@@ -2,7 +2,7 @@
 //  AppDelegate.h
 //  LevelPlayDemo
 //
-//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
+//  Copyright © 2021-2025 Unity Technologies. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/iOS/Objective C/LevelPlayDemo/AppDelegate.m
+++ b/iOS/Objective C/LevelPlayDemo/AppDelegate.m
@@ -2,7 +2,7 @@
 //  AppDelegate.m
 //  LevelPlayDemo
 //
-//  Copyright © 2024 ironSource Mobile Ltd. All rights reserved.
+//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
 //
 
 #import "AppDelegate.h"

--- a/iOS/Objective C/LevelPlayDemo/AppDelegate.m
+++ b/iOS/Objective C/LevelPlayDemo/AppDelegate.m
@@ -2,7 +2,7 @@
 //  AppDelegate.m
 //  LevelPlayDemo
 //
-//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
+//  Copyright © 2021-2025 Unity Technologies. All rights reserved.
 //
 
 #import "AppDelegate.h"

--- a/iOS/Objective C/LevelPlayDemo/DemoBannerAdDelegate.h
+++ b/iOS/Objective C/LevelPlayDemo/DemoBannerAdDelegate.h
@@ -2,7 +2,7 @@
 //  DemoBannerAdDelegate.h
 //  LevelPlayDemo
 //
-//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
+//  Copyright © 2021-2025 Unity Technologies. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/iOS/Objective C/LevelPlayDemo/DemoBannerAdDelegate.h
+++ b/iOS/Objective C/LevelPlayDemo/DemoBannerAdDelegate.h
@@ -2,7 +2,7 @@
 //  DemoBannerAdDelegate.h
 //  LevelPlayDemo
 //
-//  Copyright © 2024 ironSource Mobile Ltd. All rights reserved.
+//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/iOS/Objective C/LevelPlayDemo/DemoBannerAdDelegate.m
+++ b/iOS/Objective C/LevelPlayDemo/DemoBannerAdDelegate.m
@@ -2,7 +2,7 @@
 //  DemoBannerAdDelegate.m
 //  LevelPlayDemo
 //
-//  Copyright © 2024 ironSource Mobile Ltd. All rights reserved.
+//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
 //
 
 #import "DemoBannerAdDelegate.h"

--- a/iOS/Objective C/LevelPlayDemo/DemoBannerAdDelegate.m
+++ b/iOS/Objective C/LevelPlayDemo/DemoBannerAdDelegate.m
@@ -2,7 +2,7 @@
 //  DemoBannerAdDelegate.m
 //  LevelPlayDemo
 //
-//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
+//  Copyright © 2021-2025 Unity Technologies. All rights reserved.
 //
 
 #import "DemoBannerAdDelegate.h"

--- a/iOS/Objective C/LevelPlayDemo/DemoImpressionDataDelegate.h
+++ b/iOS/Objective C/LevelPlayDemo/DemoImpressionDataDelegate.h
@@ -2,7 +2,7 @@
 //  DemoImpressionDataDelegate.h
 //  LevelPlayDemo
 //
-//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
+//  Copyright © 2021-2025 Unity Technologies. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/iOS/Objective C/LevelPlayDemo/DemoImpressionDataDelegate.h
+++ b/iOS/Objective C/LevelPlayDemo/DemoImpressionDataDelegate.h
@@ -2,7 +2,7 @@
 //  DemoImpressionDataDelegate.h
 //  LevelPlayDemo
 //
-//  Copyright © 2024 ironSource Mobile Ltd. All rights reserved.
+//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/iOS/Objective C/LevelPlayDemo/DemoImpressionDataDelegate.m
+++ b/iOS/Objective C/LevelPlayDemo/DemoImpressionDataDelegate.m
@@ -2,7 +2,7 @@
 //  DemoImpressionDataDelegate.m
 //  LevelPlayDemo
 //
-//  Copyright © 2024 ironSource Mobile Ltd. All rights reserved.
+//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
 //
 
 #import "DemoImpressionDataDelegate.h"

--- a/iOS/Objective C/LevelPlayDemo/DemoImpressionDataDelegate.m
+++ b/iOS/Objective C/LevelPlayDemo/DemoImpressionDataDelegate.m
@@ -2,7 +2,7 @@
 //  DemoImpressionDataDelegate.m
 //  LevelPlayDemo
 //
-//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
+//  Copyright © 2021-2025 Unity Technologies. All rights reserved.
 //
 
 #import "DemoImpressionDataDelegate.h"

--- a/iOS/Objective C/LevelPlayDemo/DemoInterstitialAdDelegate.h
+++ b/iOS/Objective C/LevelPlayDemo/DemoInterstitialAdDelegate.h
@@ -2,7 +2,7 @@
 //  DemoInterstitialAdDelegate.h
 //  LevelPlayDemo
 //
-//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
+//  Copyright © 2021-2025 Unity Technologies. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/iOS/Objective C/LevelPlayDemo/DemoInterstitialAdDelegate.h
+++ b/iOS/Objective C/LevelPlayDemo/DemoInterstitialAdDelegate.h
@@ -2,7 +2,7 @@
 //  DemoInterstitialAdDelegate.h
 //  LevelPlayDemo
 //
-//  Copyright © 2024 ironSource Mobile Ltd. All rights reserved.
+//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/iOS/Objective C/LevelPlayDemo/DemoInterstitialAdDelegate.m
+++ b/iOS/Objective C/LevelPlayDemo/DemoInterstitialAdDelegate.m
@@ -2,7 +2,7 @@
 //  DemoInterstitialAdDelegate.m
 //  LevelPlayDemo
 //
-//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
+//  Copyright © 2021-2025 Unity Technologies. All rights reserved.
 //
 
 #import "DemoInterstitialAdDelegate.h"

--- a/iOS/Objective C/LevelPlayDemo/DemoInterstitialAdDelegate.m
+++ b/iOS/Objective C/LevelPlayDemo/DemoInterstitialAdDelegate.m
@@ -2,7 +2,7 @@
 //  DemoInterstitialAdDelegate.m
 //  LevelPlayDemo
 //
-//  Copyright © 2024 ironSource Mobile Ltd. All rights reserved.
+//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
 //
 
 #import "DemoInterstitialAdDelegate.h"

--- a/iOS/Objective C/LevelPlayDemo/DemoRewardedVideoAdDelegate.h
+++ b/iOS/Objective C/LevelPlayDemo/DemoRewardedVideoAdDelegate.h
@@ -2,7 +2,7 @@
 //  DemoRewardedVideoAdDelegate.h
 //  LevelPlayDemo
 //
-//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
+//  Copyright © 2021-2025 Unity Technologies. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/iOS/Objective C/LevelPlayDemo/DemoRewardedVideoAdDelegate.h
+++ b/iOS/Objective C/LevelPlayDemo/DemoRewardedVideoAdDelegate.h
@@ -2,7 +2,7 @@
 //  DemoRewardedVideoAdDelegate.h
 //  LevelPlayDemo
 //
-//  Copyright © 2024 ironSource Mobile Ltd. All rights reserved.
+//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/iOS/Objective C/LevelPlayDemo/DemoRewardedVideoAdDelegate.m
+++ b/iOS/Objective C/LevelPlayDemo/DemoRewardedVideoAdDelegate.m
@@ -2,7 +2,7 @@
 //  DemoRewardedVideoAdDelegate.m
 //  LevelPlayDemo
 //
-//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
+//  Copyright © 2021-2025 Unity Technologies. All rights reserved.
 //
 
 #import "DemoRewardedVideoAdDelegate.h"

--- a/iOS/Objective C/LevelPlayDemo/DemoRewardedVideoAdDelegate.m
+++ b/iOS/Objective C/LevelPlayDemo/DemoRewardedVideoAdDelegate.m
@@ -2,7 +2,7 @@
 //  DemoRewardedVideoAdDelegate.m
 //  LevelPlayDemo
 //
-//  Copyright © 2024 ironSource Mobile Ltd. All rights reserved.
+//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
 //
 
 #import "DemoRewardedVideoAdDelegate.h"

--- a/iOS/Objective C/LevelPlayDemo/DemoViewController.h
+++ b/iOS/Objective C/LevelPlayDemo/DemoViewController.h
@@ -2,7 +2,7 @@
 //  DemoViewController.h
 //  LevelPlayDemo
 //
-//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
+//  Copyright © 2021-2025 Unity Technologies. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/iOS/Objective C/LevelPlayDemo/DemoViewController.h
+++ b/iOS/Objective C/LevelPlayDemo/DemoViewController.h
@@ -2,7 +2,7 @@
 //  DemoViewController.h
 //  LevelPlayDemo
 //
-//  Copyright © 2024 ironSource Mobile Ltd. All rights reserved.
+//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/iOS/Objective C/LevelPlayDemo/DemoViewController.m
+++ b/iOS/Objective C/LevelPlayDemo/DemoViewController.m
@@ -2,7 +2,7 @@
 //  DemoViewController.m
 //  LevelPlayDemo
 //
-//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
+//  Copyright © 2021-2025 Unity Technologies. All rights reserved.
 
 //
 

--- a/iOS/Objective C/LevelPlayDemo/DemoViewController.m
+++ b/iOS/Objective C/LevelPlayDemo/DemoViewController.m
@@ -2,7 +2,7 @@
 //  DemoViewController.m
 //  LevelPlayDemo
 //
-//  Copyright © 2024 ironSource Mobile Ltd. All rights reserved.
+//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
 
 //
 

--- a/iOS/Objective C/LevelPlayDemo/main.m
+++ b/iOS/Objective C/LevelPlayDemo/main.m
@@ -2,7 +2,7 @@
 //  main.m
 //  LevelPlayDemo
 //
-//  Copyright © 2024 ironSource Mobile Ltd. All rights reserved.
+//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/iOS/Objective C/LevelPlayDemo/main.m
+++ b/iOS/Objective C/LevelPlayDemo/main.m
@@ -2,7 +2,7 @@
 //  main.m
 //  LevelPlayDemo
 //
-//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
+//  Copyright © 2021-2025 Unity Technologies. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/iOS/Swift/LevelPlayDemo/AppDelegate.swift
+++ b/iOS/Swift/LevelPlayDemo/AppDelegate.swift
@@ -2,7 +2,7 @@
 //  AppDelegate.swift
 //  LevelPlayDemo
 //
-//  Copyright © 2024 ironSource Mobile Ltd. All rights reserved.
+//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
 //
 
 import UIKit

--- a/iOS/Swift/LevelPlayDemo/AppDelegate.swift
+++ b/iOS/Swift/LevelPlayDemo/AppDelegate.swift
@@ -2,7 +2,7 @@
 //  AppDelegate.swift
 //  LevelPlayDemo
 //
-//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
+//  Copyright © 2021-2025 Unity Technologies. All rights reserved.
 //
 
 import UIKit

--- a/iOS/Swift/LevelPlayDemo/DemoBannerAdDelegate.swift
+++ b/iOS/Swift/LevelPlayDemo/DemoBannerAdDelegate.swift
@@ -2,7 +2,7 @@
 //  DemoBannerAdDelegate.swift
 //  LevelPlayDemo
 //
-//  Copyright © 2024 ironSource Mobile Ltd. All rights reserved.
+//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
 //
 
 import Foundation

--- a/iOS/Swift/LevelPlayDemo/DemoBannerAdDelegate.swift
+++ b/iOS/Swift/LevelPlayDemo/DemoBannerAdDelegate.swift
@@ -2,7 +2,7 @@
 //  DemoBannerAdDelegate.swift
 //  LevelPlayDemo
 //
-//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
+//  Copyright © 2021-2025 Unity Technologies. All rights reserved.
 //
 
 import Foundation

--- a/iOS/Swift/LevelPlayDemo/DemoImpressionDataDelegate.swift
+++ b/iOS/Swift/LevelPlayDemo/DemoImpressionDataDelegate.swift
@@ -2,7 +2,7 @@
 //  DemoImpressionDataDelegate.swift
 //  LevelPlayDemo
 //
-//  Copyright © 2024 ironSource Mobile Ltd. All rights reserved.
+//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
 //
 
 import Foundation

--- a/iOS/Swift/LevelPlayDemo/DemoImpressionDataDelegate.swift
+++ b/iOS/Swift/LevelPlayDemo/DemoImpressionDataDelegate.swift
@@ -2,7 +2,7 @@
 //  DemoImpressionDataDelegate.swift
 //  LevelPlayDemo
 //
-//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
+//  Copyright © 2021-2025 Unity Technologies. All rights reserved.
 //
 
 import Foundation

--- a/iOS/Swift/LevelPlayDemo/DemoInterstitialAdDelegate.swift
+++ b/iOS/Swift/LevelPlayDemo/DemoInterstitialAdDelegate.swift
@@ -2,7 +2,7 @@
 //  DemoInterstitialAdDelegate.swift
 //  LevelPlayDemo
 //
-//  Copyright © 2024 ironSource Mobile Ltd. All rights reserved.
+//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
 //
 
 import Foundation

--- a/iOS/Swift/LevelPlayDemo/DemoInterstitialAdDelegate.swift
+++ b/iOS/Swift/LevelPlayDemo/DemoInterstitialAdDelegate.swift
@@ -2,7 +2,7 @@
 //  DemoInterstitialAdDelegate.swift
 //  LevelPlayDemo
 //
-//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
+//  Copyright © 2021-2025 Unity Technologies. All rights reserved.
 //
 
 import Foundation

--- a/iOS/Swift/LevelPlayDemo/DemoRewardedVideoAdDelegate.swift
+++ b/iOS/Swift/LevelPlayDemo/DemoRewardedVideoAdDelegate.swift
@@ -2,7 +2,7 @@
 //  DemoRewardedVideoAdDelegate.swift
 //  LevelPlayDemo
 //
-//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
+//  Copyright © 2021-2025 Unity Technologies. All rights reserved.
 //
 
 import Foundation

--- a/iOS/Swift/LevelPlayDemo/DemoRewardedVideoAdDelegate.swift
+++ b/iOS/Swift/LevelPlayDemo/DemoRewardedVideoAdDelegate.swift
@@ -2,7 +2,7 @@
 //  DemoRewardedVideoAdDelegate.swift
 //  LevelPlayDemo
 //
-//  Copyright © 2024 ironSource Mobile Ltd. All rights reserved.
+//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
 //
 
 import Foundation

--- a/iOS/Swift/LevelPlayDemo/DemoViewController.swift
+++ b/iOS/Swift/LevelPlayDemo/DemoViewController.swift
@@ -2,7 +2,7 @@
 //  DemoViewController.swift
 //  LevelPlayDemo
 //
-//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
+//  Copyright © 2021-2025 Unity Technologies. All rights reserved.
 //
 
 import UIKit

--- a/iOS/Swift/LevelPlayDemo/DemoViewController.swift
+++ b/iOS/Swift/LevelPlayDemo/DemoViewController.swift
@@ -2,7 +2,7 @@
 //  DemoViewController.swift
 //  LevelPlayDemo
 //
-//  Copyright © 2024 ironSource Mobile Ltd. All rights reserved.
+//  Copyright © 2025 LevelPlay Ltd. All rights reserved.
 //
 
 import UIKit


### PR DESCRIPTION
Update copyright messages for LevelPlay rebranding
Updated all copyright messages across the iOS demo apps from "IronSource Mobile Ltd." to "Unity Technologies" with the correct year range (2021-2025) to reflect the LevelPlay rebranding.
Changes:
LICENSE file: Updated main copyright notice
iOS Swift demo (6 files): Updated copyright headers
iOS Objective-C demo (13 files): Updated copyright headers
Format: Copyright © 2021-2025 Unity Technologies. All rights reserved.
No functional changes to the demo applications.