### PR TITLE
Migrate impression data listener to the per-ad-unit API (LevelPlay 9.5.0)

### DIFF
--- a/.github/workflows/ios-integration-tests.yml
+++ b/.github/workflows/ios-integration-tests.yml
@@ -36,7 +36,7 @@ jobs:
           xcodebuild test \
             -workspace ${{ matrix.project.workspace }} \
             -scheme LevelPlayDemo \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' \
             -resultBundlePath TestResults
 
       - name: Upload test results

--- a/.github/workflows/ios-integration-tests.yml
+++ b/.github/workflows/ios-integration-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   integration-tests:
-    runs-on: macos-latest
+    runs-on: macos-26
     strategy:
       matrix:
         project:

--- a/.github/workflows/ios-integration-tests.yml
+++ b/.github/workflows/ios-integration-tests.yml
@@ -27,6 +27,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # IronSourceSDK 9.5.0.0 is built with the Xcode 26 toolchain. The macos-26
+      # runner defaults to Xcode 26.5, which fails to link the Objective-C app
+      # target against the Swift static pods (missing swiftCompatibility libs).
+      # 26.6 links cleanly, so pin it explicitly.
+      - name: Select Xcode 26.6
+        run: sudo xcode-select -s /Applications/Xcode_26.6.app
+
       - name: Install CocoaPods dependencies
         if: matrix.project.uses_cocoapods
         run: pod install

--- a/.github/workflows/ios-integration-tests.yml
+++ b/.github/workflows/ios-integration-tests.yml
@@ -27,10 +27,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # IronSourceSDK 9.5.0.0 is built with the Xcode 26 toolchain. The macos-26
-      # runner defaults to Xcode 26.5, which fails to link the Objective-C app
-      # target against the Swift static pods (missing swiftCompatibility libs).
-      # 26.6 links cleanly, so pin it explicitly.
       - name: Select Xcode 26.6
         run: sudo xcode-select -s /Applications/Xcode_26.6.app
 

--- a/Android/Java/app/src/androidTest/java/com/unity3d/levelplaydemo/BannerInitLoadAndImpressionIntegrationTest.java
+++ b/Android/Java/app/src/androidTest/java/com/unity3d/levelplaydemo/BannerInitLoadAndImpressionIntegrationTest.java
@@ -54,13 +54,6 @@ public class BannerInitLoadAndImpressionIntegrationTest {
                 )
         );
 
-        LevelPlay.addImpressionDataListener(new LevelPlayImpressionDataListener() {
-            @Override
-            public void onImpressionSuccess(@NonNull LevelPlayImpressionData impressionData) {
-                impressionLatch.countDown();
-            }
-        });
-
         // When
         activityRule.getScenario().onActivity(activity -> {
             LevelPlayInitRequest request = new LevelPlayInitRequest.Builder(DemoActivity.APP_KEY).build();
@@ -106,6 +99,13 @@ public class BannerInitLoadAndImpressionIntegrationTest {
 
                         @Override
                         public void onAdLeftApplication(@NonNull LevelPlayAdInfo adInfo) {}
+                    });
+
+                    bannerAd.setImpressionDataListener(new LevelPlayImpressionDataListener() {
+                        @Override
+                        public void onImpressionSuccess(@NonNull LevelPlayImpressionData impressionData) {
+                            impressionLatch.countDown();
+                        }
                     });
 
                     FrameLayout bannerContainer = activity.findViewById(R.id.banner_frame_layout);

--- a/Android/Java/app/src/androidTest/java/com/unity3d/levelplaydemo/InterstitialInitLoadShowAndImpressionIntegrationTest.java
+++ b/Android/Java/app/src/androidTest/java/com/unity3d/levelplaydemo/InterstitialInitLoadShowAndImpressionIntegrationTest.java
@@ -51,13 +51,6 @@ public class InterstitialInitLoadShowAndImpressionIntegrationTest {
                 )
         );
 
-        LevelPlay.addImpressionDataListener(new LevelPlayImpressionDataListener() {
-            @Override
-            public void onImpressionSuccess(@NonNull LevelPlayImpressionData impressionData) {
-                impressionLatch.countDown();
-            }
-        });
-
         // When
         activityRule.getScenario().onActivity(activity -> {
             LevelPlayInitRequest request = new LevelPlayInitRequest.Builder(DemoActivity.APP_KEY).build();
@@ -92,6 +85,12 @@ public class InterstitialInitLoadShowAndImpressionIntegrationTest {
 
                         @Override
                         public void onAdInfoChanged(@NonNull LevelPlayAdInfo adInfo) {}
+                    });
+                    interstitialAdHolder[0].setImpressionDataListener(new LevelPlayImpressionDataListener() {
+                        @Override
+                        public void onImpressionSuccess(@NonNull LevelPlayImpressionData impressionData) {
+                            impressionLatch.countDown();
+                        }
                     });
                     interstitialAdHolder[0].loadAd();
                 }

--- a/Android/Java/app/src/androidTest/java/com/unity3d/levelplaydemo/RewardedInitLoadShowAndImpressionIntegrationTest.java
+++ b/Android/Java/app/src/androidTest/java/com/unity3d/levelplaydemo/RewardedInitLoadShowAndImpressionIntegrationTest.java
@@ -52,13 +52,6 @@ public class RewardedInitLoadShowAndImpressionIntegrationTest {
                 )
         );
 
-        LevelPlay.addImpressionDataListener(new LevelPlayImpressionDataListener() {
-            @Override
-            public void onImpressionSuccess(@NonNull LevelPlayImpressionData impressionData) {
-                impressionLatch.countDown();
-            }
-        });
-
         // When
         activityRule.getScenario().onActivity(activity -> {
             LevelPlayInitRequest request = new LevelPlayInitRequest.Builder(DemoActivity.APP_KEY).build();
@@ -96,6 +89,12 @@ public class RewardedInitLoadShowAndImpressionIntegrationTest {
 
                         @Override
                         public void onAdInfoChanged(@NonNull LevelPlayAdInfo adInfo) {}
+                    });
+                    rewardedAdHolder[0].setImpressionDataListener(new LevelPlayImpressionDataListener() {
+                        @Override
+                        public void onImpressionSuccess(@NonNull LevelPlayImpressionData impressionData) {
+                            impressionLatch.countDown();
+                        }
                     });
                     rewardedAdHolder[0].loadAd();
                 }

--- a/Android/Java/app/src/main/java/com/unity3d/levelplaydemo/DemoActivity.java
+++ b/Android/Java/app/src/main/java/com/unity3d/levelplaydemo/DemoActivity.java
@@ -87,8 +87,6 @@ public class DemoActivity extends Activity implements DemoActivityListener {
             LevelPlay.validateIntegration(this);
         }
 
-        LevelPlay.addImpressionDataListener(new DemoImpressionDataListener());
-
         // After setting the listeners you can go ahead and initialize the SDK.
         // Once the initialization callback is returned you can start loading your ads
 
@@ -106,6 +104,7 @@ public class DemoActivity extends Activity implements DemoActivityListener {
     public void createInterstitialAd() {
         interstitialAd = new LevelPlayInterstitialAd(INTERSTITIAL_AD_UNIT_ID);
         interstitialAd.setListener(new DemoInterstitialAdListener(this));
+        interstitialAd.setImpressionDataListener(new DemoImpressionDataListener());
 
         setEnablementForButton(DemoButtonIdentifiers.LOAD_INTERSTITIAL_BUTTON_IDENTIFIER, true);
     }
@@ -151,6 +150,7 @@ public class DemoActivity extends Activity implements DemoActivityListener {
 
             // set the banner listener
             bannerAd.setBannerListener(new DemoBannerAdListener(this));
+            bannerAd.setImpressionDataListener(new DemoImpressionDataListener());
 
             // add LevelPlayBannerAdView to your container
             FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT);
@@ -181,6 +181,7 @@ public class DemoActivity extends Activity implements DemoActivityListener {
     public void createRewardedAd() {
         rewardedAd = new LevelPlayRewardedAd(REWARDED_AD_UNIT_ID);
         rewardedAd.setListener(new DemoRewardedVideoAdListener(this));
+        rewardedAd.setImpressionDataListener(new DemoImpressionDataListener());
 
         setEnablementForButton(DemoButtonIdentifiers.LOAD_REWARDED_VIDEO_BUTTON_IDENTIFIER, true);
     }

--- a/Android/Kotlin/app/src/androidTest/java/com/unity3d/levelplaydemo/BannerInitLoadAndImpressionIntegrationTest.kt
+++ b/Android/Kotlin/app/src/androidTest/java/com/unity3d/levelplaydemo/BannerInitLoadAndImpressionIntegrationTest.kt
@@ -44,12 +44,6 @@ class BannerInitLoadAndImpressionIntegrationTest {
             activity.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
 
-        LevelPlay.addImpressionDataListener(object : LevelPlayImpressionDataListener {
-            override fun onImpressionSuccess(impressionData: LevelPlayImpressionData) {
-                impressionLatch.countDown()
-            }
-        })
-
         // When
         activityRule.scenario.onActivity { activity ->
             val request = LevelPlayInitRequest.Builder(DemoActivity.APP_KEY).build()
@@ -80,6 +74,12 @@ class BannerInitLoadAndImpressionIntegrationTest {
                         override fun onAdExpanded(adInfo: LevelPlayAdInfo) {}
                         override fun onAdCollapsed(adInfo: LevelPlayAdInfo) {}
                         override fun onAdLeftApplication(adInfo: LevelPlayAdInfo) {}
+                    })
+
+                    bannerAd.setImpressionDataListener(object : LevelPlayImpressionDataListener {
+                        override fun onImpressionSuccess(impressionData: LevelPlayImpressionData) {
+                            impressionLatch.countDown()
+                        }
                     })
 
                     val bannerContainer = activity.findViewById<FrameLayout>(R.id.banner_footer)

--- a/Android/Kotlin/app/src/androidTest/java/com/unity3d/levelplaydemo/InterstitialInitLoadShowAndImpressionIntegrationTest.kt
+++ b/Android/Kotlin/app/src/androidTest/java/com/unity3d/levelplaydemo/InterstitialInitLoadShowAndImpressionIntegrationTest.kt
@@ -42,12 +42,6 @@ class InterstitialInitLoadShowAndImpressionIntegrationTest {
             activity.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
 
-        LevelPlay.addImpressionDataListener(object : LevelPlayImpressionDataListener {
-            override fun onImpressionSuccess(impressionData: LevelPlayImpressionData) {
-                impressionLatch.countDown()
-            }
-        })
-
         // When
         activityRule.scenario.onActivity { activity ->
             val request = LevelPlayInitRequest.Builder(DemoActivity.APP_KEY).build()
@@ -70,6 +64,11 @@ class InterstitialInitLoadShowAndImpressionIntegrationTest {
                         override fun onAdClicked(adInfo: LevelPlayAdInfo) {}
                         override fun onAdClosed(adInfo: LevelPlayAdInfo) {}
                         override fun onAdInfoChanged(adInfo: LevelPlayAdInfo) {}
+                    })
+                    interstitialAd?.setImpressionDataListener(object : LevelPlayImpressionDataListener {
+                        override fun onImpressionSuccess(impressionData: LevelPlayImpressionData) {
+                            impressionLatch.countDown()
+                        }
                     })
                     interstitialAd?.loadAd()
                 }

--- a/Android/Kotlin/app/src/androidTest/java/com/unity3d/levelplaydemo/RewardedInitLoadShowAndImpressionIntegrationTest.kt
+++ b/Android/Kotlin/app/src/androidTest/java/com/unity3d/levelplaydemo/RewardedInitLoadShowAndImpressionIntegrationTest.kt
@@ -43,12 +43,6 @@ class RewardedInitLoadShowAndImpressionIntegrationTest {
             activity.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
 
-        LevelPlay.addImpressionDataListener(object : LevelPlayImpressionDataListener {
-            override fun onImpressionSuccess(impressionData: LevelPlayImpressionData) {
-                impressionLatch.countDown()
-            }
-        })
-
         // When
         activityRule.scenario.onActivity { activity ->
             val request = LevelPlayInitRequest.Builder(DemoActivity.APP_KEY).build()
@@ -72,6 +66,11 @@ class RewardedInitLoadShowAndImpressionIntegrationTest {
                         override fun onAdClosed(adInfo: LevelPlayAdInfo) {}
                         override fun onAdRewarded(reward: LevelPlayReward, adInfo: LevelPlayAdInfo) {}
                         override fun onAdInfoChanged(adInfo: LevelPlayAdInfo) {}
+                    })
+                    rewardedAd?.setImpressionDataListener(object : LevelPlayImpressionDataListener {
+                        override fun onImpressionSuccess(impressionData: LevelPlayImpressionData) {
+                            impressionLatch.countDown()
+                        }
                     })
                     rewardedAd?.loadAd()
                 }

--- a/Android/Kotlin/app/src/main/java/com/unity3d/levelplaydemo/DemoActivity.kt
+++ b/Android/Kotlin/app/src/main/java/com/unity3d/levelplaydemo/DemoActivity.kt
@@ -95,8 +95,6 @@ class DemoActivity : Activity(), DemoActivityListener {
             LevelPlay.validateIntegration(this)
         }
 
-        LevelPlay.addImpressionDataListener(DemoImpressionDataListener())
-
         // After setting the listeners you can go ahead and initialize the SDK.
         // Once the initialization callback is returned you can start loading your ads
 
@@ -114,6 +112,7 @@ class DemoActivity : Activity(), DemoActivityListener {
     override fun createInterstitialAd() {
         interstitialAd = LevelPlayInterstitialAd(INTERSTITIAL_AD_UNIT_ID)
         interstitialAd?.setListener(DemoInterstitialAdListener(this))
+        interstitialAd?.setImpressionDataListener(DemoImpressionDataListener())
 
         setEnablementForButton(DemoButtonIdentifiers.LOAD_INTERSTITIAL_BUTTON_IDENTIFIER, true)
     }
@@ -160,6 +159,7 @@ class DemoActivity : Activity(), DemoActivityListener {
 
             // set the banner listener
             bannerAd?.setBannerListener(DemoBannerAdListener(this))
+            bannerAd?.setImpressionDataListener(DemoImpressionDataListener())
 
             // add LevelPlayBannerAdView to your container
             val layoutParams = FrameLayout.LayoutParams(
@@ -191,6 +191,7 @@ class DemoActivity : Activity(), DemoActivityListener {
     override fun createRewardedAd() {
         rewardedAd = LevelPlayRewardedAd(REWARDED_AD_UNIT_ID)
         rewardedAd?.setListener(DemoRewardedAdListener(this))
+        rewardedAd?.setImpressionDataListener(DemoImpressionDataListener())
 
         setEnablementForButton(DemoButtonIdentifiers.LOAD_REWARDED_VIDEO_BUTTON_IDENTIFIER, true)
     }

--- a/iOS/Objective C/LevelPlayDemo.xcodeproj/project.pbxproj
+++ b/iOS/Objective C/LevelPlayDemo.xcodeproj/project.pbxproj
@@ -592,7 +592,10 @@
 				INFOPLIST_FILE = "$(SRCROOT)/LevelPlayDemo/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) /usr/lib/swift @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME)",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"$(inherited)",
@@ -617,7 +620,10 @@
 				INFOPLIST_FILE = "$(SRCROOT)/LevelPlayDemo/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) /usr/lib/swift @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME)",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"$(inherited)",

--- a/iOS/Objective C/LevelPlayDemo/DemoViewController.m
+++ b/iOS/Objective C/LevelPlayDemo/DemoViewController.m
@@ -18,15 +18,16 @@
 @property (nonatomic, strong) DemoRewardedVideoAdDelegate         *rewardedVideoDelegate;
 @property (nonatomic, strong) LPMRewardedAd                       *rewardedAd;
 @property (nonatomic, strong) LPMReward                           *reward;
+@property (nonatomic, strong) DemoImpressionDataDelegate          *rewardedImpressionDataDelegate;
 
 @property (nonatomic, strong) DemoInterstitialAdDelegate          *interstitialAdDelegate;
 @property (nonatomic, strong) LPMInterstitialAd                   *interstitialAd;
+@property (nonatomic, strong) DemoImpressionDataDelegate          *interstitialImpressionDataDelegate;
 
 @property (nonatomic, strong) DemoBannerAdDelegate                *bannerAdViewDelegate;
 @property (nonatomic, strong) LPMBannerAdView                     *bannerAd;
 @property (nonatomic, strong) LPMAdSize                           *bannerSize;
-
-@property (nonatomic, strong) DemoImpressionDataDelegate          *impressionDataDelegate;
+@property (nonatomic, strong) DemoImpressionDataDelegate          *bannerImpressionDataDelegate;
 
 @end
 
@@ -70,11 +71,6 @@
     // Remove it before going live!
     [LevelPlay validateIntegration];
 #endif
-    
-    self.impressionDataDelegate = [[DemoImpressionDataDelegate alloc] init];
-    [LevelPlay addImpressionDataDelegate:self.impressionDataDelegate];
-        
-    // After setting the delegates you can go ahead and initialize the SDK. 
     // Once the initialization callback is return you can start loading your ads
     
     [self logMethodName:[NSString stringWithFormat:@"init levelPlay SDK with appKey: %@", kAppKey]];
@@ -103,7 +99,9 @@
     self.interstitialAd = [[LPMInterstitialAd alloc] initWithAdUnitId:kInterstitialAdUnitId];
     self.interstitialAdDelegate = [[DemoInterstitialAdDelegate alloc] initWithDelegate:self];
     self.interstitialAd.delegate = self.interstitialAdDelegate;
-    
+    self.interstitialImpressionDataDelegate = [[DemoImpressionDataDelegate alloc] init];
+    [self.interstitialAd setImpressionDataDelegate:self.interstitialImpressionDataDelegate];
+
     [self setEnablementForButton:LoadInterstitialButtonIdentifier
                                    enable:YES];
 }
@@ -150,7 +148,9 @@
         // set the banner listener
         self.bannerAdViewDelegate = [[DemoBannerAdDelegate alloc] initWithDelegate:self];
         [self.bannerAd setDelegate:self.bannerAdViewDelegate];
-        
+        self.bannerImpressionDataDelegate = [[DemoImpressionDataDelegate alloc] init];
+        [self.bannerAd setImpressionDataDelegate:self.bannerImpressionDataDelegate];
+
         [self addBannerToView];
         
         [self setEnablementForButton:LoadBannerButtonIdentifier
@@ -190,7 +190,9 @@
   self.rewardedAd = [[LPMRewardedAd alloc] initWithAdUnitId:kRewardedAdUnit];
   self.rewardedVideoDelegate = [[DemoRewardedVideoAdDelegate alloc] initWithDelegate:self];
   self.rewardedAd.delegate = self.rewardedVideoDelegate;
-  
+  self.rewardedImpressionDataDelegate = [[DemoImpressionDataDelegate alloc] init];
+  [self.rewardedAd setImpressionDataDelegate:self.rewardedImpressionDataDelegate];
+
   [self setEnablementForButton:LoadRewardedVideoButtonIdentifier
                         enable:YES];
 }

--- a/iOS/Objective C/LevelPlayDemoTests/BannerInitLoadAndImpressionIntegrationTest.swift
+++ b/iOS/Objective C/LevelPlayDemoTests/BannerInitLoadAndImpressionIntegrationTest.swift
@@ -2,63 +2,68 @@ import Testing
 import IronSource
 import UIKit
 
-@Test(.timeLimit(.minutes(1)))
-@MainActor
-func testShouldInitLoadBannerAndReceiveImpression() async throws {
+@Suite(.serialized)
+struct AdIntegrationTests {}
+
+extension AdIntegrationTests {
+  @Test(.timeLimit(.minutes(1)))
+  @MainActor
+  func testShouldInitLoadBannerAndReceiveImpression() async throws {
     // Given
     let delegate = BannerTestDelegate()
     let impressionDelegate = BannerImpressionDelegate()
-
+    
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-        let requestBuilder = LPMInitRequestBuilder(appKey: kAppKey)
-        let initRequest = requestBuilder.build()
-        LevelPlay.initWith(initRequest) { config, error in
-            if let error = error {
-                continuation.resume(throwing: error)
-            } else {
-                continuation.resume()
-            }
+      let requestBuilder = LPMInitRequestBuilder(appKey: kAppKey)
+      let initRequest = requestBuilder.build()
+      LevelPlay.initWith(initRequest) { config, error in
+        if let error = error {
+          continuation.resume(throwing: error)
+        } else {
+          continuation.resume()
         }
+      }
     }
-
+    
     let bannerSize = LPMAdSize.createAdaptive()!
     let config = LPMBannerAdViewConfigBuilder().set(adSize: bannerSize).build()
     let bannerAd = LPMBannerAdView(adUnitId: kBannerAdUnitId, config: config)
     bannerAd.setDelegate(delegate)
     bannerAd.setImpressionDataDelegate(impressionDelegate)
-
+    
     let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
     let rootVC = windowScene?.windows.first(where: { $0.isKeyWindow })?.rootViewController
-
+    
     bannerAd.translatesAutoresizingMaskIntoConstraints = false
     rootVC!.view.addSubview(bannerAd)
     NSLayoutConstraint.activate([
-        bannerAd.centerXAnchor.constraint(equalTo: rootVC!.view.centerXAnchor),
-        bannerAd.bottomAnchor.constraint(equalTo: rootVC!.view.safeAreaLayoutGuide.bottomAnchor),
-        bannerAd.widthAnchor.constraint(equalToConstant: CGFloat(bannerSize.width)),
-        bannerAd.heightAnchor.constraint(equalToConstant: CGFloat(bannerSize.height))
+      bannerAd.centerXAnchor.constraint(equalTo: rootVC!.view.centerXAnchor),
+      bannerAd.bottomAnchor.constraint(equalTo: rootVC!.view.safeAreaLayoutGuide.bottomAnchor),
+      bannerAd.widthAnchor.constraint(equalToConstant: CGFloat(bannerSize.width)),
+      bannerAd.heightAnchor.constraint(equalToConstant: CGFloat(bannerSize.height))
     ])
-
+    
     // When
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-        delegate.onLoad = { continuation.resume() }
-        delegate.onLoadFail = { error in continuation.resume(throwing: error) }
-        bannerAd.loadAd(with: rootVC!)
+      delegate.onLoad = { continuation.resume() }
+      delegate.onLoadFail = { error in continuation.resume(throwing: error) }
+      bannerAd.loadAd(with: rootVC!)
     }
-
+    
     // Then
     if !impressionDelegate.received {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            if impressionDelegate.received {
-                continuation.resume()
-            } else {
-                impressionDelegate.onImpression = { continuation.resume() }
-            }
+      try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+        if impressionDelegate.received {
+          continuation.resume()
+        } else {
+          impressionDelegate.onImpression = { continuation.resume() }
         }
+      }
     }
-
+    
     bannerAd.removeFromSuperview()
     bannerAd.destroy()
+  }
 }
 
 private class BannerTestDelegate: NSObject, LPMBannerAdViewDelegate {

--- a/iOS/Objective C/LevelPlayDemoTests/BannerInitLoadAndImpressionIntegrationTest.swift
+++ b/iOS/Objective C/LevelPlayDemoTests/BannerInitLoadAndImpressionIntegrationTest.swift
@@ -9,8 +9,6 @@ func testShouldInitLoadBannerAndReceiveImpression() async throws {
     let delegate = BannerTestDelegate()
     let impressionDelegate = BannerImpressionDelegate()
 
-    LevelPlay.add(impressionDelegate as LPMImpressionDataDelegate)
-
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
         let requestBuilder = LPMInitRequestBuilder(appKey: kAppKey)
         let initRequest = requestBuilder.build()
@@ -27,6 +25,7 @@ func testShouldInitLoadBannerAndReceiveImpression() async throws {
     let config = LPMBannerAdViewConfigBuilder().set(adSize: bannerSize).build()
     let bannerAd = LPMBannerAdView(adUnitId: kBannerAdUnitId, config: config)
     bannerAd.setDelegate(delegate)
+    bannerAd.setImpressionDataDelegate(impressionDelegate)
 
     let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
     let rootVC = windowScene?.windows.first(where: { $0.isKeyWindow })?.rootViewController

--- a/iOS/Objective C/LevelPlayDemoTests/InterstitialInitLoadShowAndImpressionIntegrationTest.swift
+++ b/iOS/Objective C/LevelPlayDemoTests/InterstitialInitLoadShowAndImpressionIntegrationTest.swift
@@ -2,63 +2,72 @@ import Testing
 import IronSource
 import UIKit
 
-@Test(.timeLimit(.minutes(1)))
-@MainActor
-func testShouldInitLoadShowInterstitialAndReceiveImpression() async throws {
+extension AdIntegrationTests {
+  @Test(.timeLimit(.minutes(1)))
+  @MainActor
+  func testShouldInitLoadShowInterstitialAndReceiveImpression() async throws {
     // Given
     let delegate = InterstitialTestDelegate()
     let impressionDelegate = TestImpressionDelegate()
-
+    
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-        let requestBuilder = LPMInitRequestBuilder(appKey: kAppKey)
-        let initRequest = requestBuilder.build()
-        LevelPlay.initWith(initRequest) { config, error in
-            if let error = error {
-                continuation.resume(throwing: error)
-            } else {
-                continuation.resume()
-            }
+      let requestBuilder = LPMInitRequestBuilder(appKey: kAppKey)
+      let initRequest = requestBuilder.build()
+      LevelPlay.initWith(initRequest) { config, error in
+        if let error = error {
+          continuation.resume(throwing: error)
+        } else {
+          continuation.resume()
         }
+      }
     }
-
+    
     let interstitialAd = LPMInterstitialAd(adUnitId: kInterstitialAdUnitId)
     interstitialAd.setDelegate(delegate)
     interstitialAd.setImpressionDataDelegate(impressionDelegate)
-
+    
     // When
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-        delegate.onLoad = { continuation.resume() }
-        delegate.onLoadFail = { error in continuation.resume(throwing: error) }
-        interstitialAd.loadAd()
+      delegate.onLoad = { continuation.resume() }
+      delegate.onLoadFail = { error in continuation.resume(throwing: error) }
+      interstitialAd.loadAd()
     }
-
+    
     let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
     let rootVC = windowScene?.windows.first(where: { $0.isKeyWindow })?.rootViewController
-
+    
     interstitialAd.showAd(viewController: rootVC!, placementName: nil as String?)
-
+    
     // Then
     if !impressionDelegate.received {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            if impressionDelegate.received {
-                continuation.resume()
-            } else {
-                impressionDelegate.onImpression = { continuation.resume() }
-            }
+      try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+        if impressionDelegate.received {
+          continuation.resume()
+        } else {
+          impressionDelegate.onImpression = { continuation.resume() }
         }
+      }
     }
+    
+    // Cleanup: dismiss the fullscreen ad so a subsequent test can present one
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      delegate.onClose = { continuation.resume() }
+      rootVC?.dismiss(animated: false)
+    }
+  }
 }
 
 private class InterstitialTestDelegate: NSObject, LPMInterstitialAdDelegate {
     var onLoad: (() -> Void)?
     var onLoadFail: ((Error) -> Void)?
+    var onClose: (() -> Void)?
 
     func didLoadAd(with adInfo: LPMAdInfo) { onLoad?() }
     func didFailToLoadAd(withAdUnitId adUnitId: String, error: Error) { onLoadFail?(error) }
     func didDisplayAd(with adInfo: LPMAdInfo) {}
     func didFailToDisplayAd(with adInfo: LPMAdInfo, error: Error) {}
     func didClickAd(with adInfo: LPMAdInfo) {}
-    func didCloseAd(with adInfo: LPMAdInfo) {}
+    func didCloseAd(with adInfo: LPMAdInfo) { onClose?() }
     func didChangeAdInfo(_ adInfo: LPMAdInfo) {}
 }
 

--- a/iOS/Objective C/LevelPlayDemoTests/InterstitialInitLoadShowAndImpressionIntegrationTest.swift
+++ b/iOS/Objective C/LevelPlayDemoTests/InterstitialInitLoadShowAndImpressionIntegrationTest.swift
@@ -9,8 +9,6 @@ func testShouldInitLoadShowInterstitialAndReceiveImpression() async throws {
     let delegate = InterstitialTestDelegate()
     let impressionDelegate = TestImpressionDelegate()
 
-    LevelPlay.add(impressionDelegate as LPMImpressionDataDelegate)
-
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
         let requestBuilder = LPMInitRequestBuilder(appKey: kAppKey)
         let initRequest = requestBuilder.build()
@@ -25,6 +23,7 @@ func testShouldInitLoadShowInterstitialAndReceiveImpression() async throws {
 
     let interstitialAd = LPMInterstitialAd(adUnitId: kInterstitialAdUnitId)
     interstitialAd.setDelegate(delegate)
+    interstitialAd.setImpressionDataDelegate(impressionDelegate)
 
     // When
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in

--- a/iOS/Objective C/LevelPlayDemoTests/RewardedInitLoadShowAndImpressionIntegrationTest.swift
+++ b/iOS/Objective C/LevelPlayDemoTests/RewardedInitLoadShowAndImpressionIntegrationTest.swift
@@ -2,63 +2,72 @@ import Testing
 import IronSource
 import UIKit
 
-@Test(.timeLimit(.minutes(1)))
-@MainActor
-func testShouldInitLoadShowRewardedAndReceiveImpression() async throws {
+extension AdIntegrationTests {
+  @Test(.timeLimit(.minutes(1)))
+  @MainActor
+  func testShouldInitLoadShowRewardedAndReceiveImpression() async throws {
     // Given
     let delegate = RewardedTestDelegate()
     let impressionDelegate = RewardedImpressionDelegate()
-
+    
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-        let requestBuilder = LPMInitRequestBuilder(appKey: kAppKey)
-        let initRequest = requestBuilder.build()
-        LevelPlay.initWith(initRequest) { config, error in
-            if let error = error {
-                continuation.resume(throwing: error)
-            } else {
-                continuation.resume()
-            }
+      let requestBuilder = LPMInitRequestBuilder(appKey: kAppKey)
+      let initRequest = requestBuilder.build()
+      LevelPlay.initWith(initRequest) { config, error in
+        if let error = error {
+          continuation.resume(throwing: error)
+        } else {
+          continuation.resume()
         }
+      }
     }
-
+    
     let rewardedAd = LPMRewardedAd(adUnitId: kRewardedAdUnit)
     rewardedAd.setDelegate(delegate)
     rewardedAd.setImpressionDataDelegate(impressionDelegate)
-
+    
     // When
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-        delegate.onLoad = { continuation.resume() }
-        delegate.onLoadFail = { error in continuation.resume(throwing: error) }
-        rewardedAd.loadAd()
+      delegate.onLoad = { continuation.resume() }
+      delegate.onLoadFail = { error in continuation.resume(throwing: error) }
+      rewardedAd.loadAd()
     }
-
+    
     let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
     let rootVC = windowScene?.windows.first(where: { $0.isKeyWindow })?.rootViewController
-
+    
     rewardedAd.showAd(viewController: rootVC!, placementName: nil as String?)
-
+    
     // Then
     if !impressionDelegate.received {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            if impressionDelegate.received {
-                continuation.resume()
-            } else {
-                impressionDelegate.onImpression = { continuation.resume() }
-            }
+      try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+        if impressionDelegate.received {
+          continuation.resume()
+        } else {
+          impressionDelegate.onImpression = { continuation.resume() }
         }
+      }
     }
+    
+    // Cleanup: dismiss the fullscreen ad so a subsequent test can present one
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      delegate.onClose = { continuation.resume() }
+      rootVC?.dismiss(animated: false)
+    }
+  }
 }
 
 private class RewardedTestDelegate: NSObject, LPMRewardedAdDelegate {
     var onLoad: (() -> Void)?
     var onLoadFail: ((Error) -> Void)?
+    var onClose: (() -> Void)?
 
     func didLoadAd(with adInfo: LPMAdInfo) { onLoad?() }
     func didFailToLoadAd(withAdUnitId adUnitId: String, error: Error) { onLoadFail?(error) }
     func didDisplayAd(with adInfo: LPMAdInfo) {}
     func didFailToDisplayAd(with adInfo: LPMAdInfo, error: Error) {}
     func didClickAd(with adInfo: LPMAdInfo) {}
-    func didCloseAd(with adInfo: LPMAdInfo) {}
+    func didCloseAd(with adInfo: LPMAdInfo) { onClose?() }
     func didRewardAd(with adInfo: LPMAdInfo, reward: LPMReward) {}
     func didChangeAdInfo(_ adInfo: LPMAdInfo) {}
 }

--- a/iOS/Objective C/LevelPlayDemoTests/RewardedInitLoadShowAndImpressionIntegrationTest.swift
+++ b/iOS/Objective C/LevelPlayDemoTests/RewardedInitLoadShowAndImpressionIntegrationTest.swift
@@ -9,8 +9,6 @@ func testShouldInitLoadShowRewardedAndReceiveImpression() async throws {
     let delegate = RewardedTestDelegate()
     let impressionDelegate = RewardedImpressionDelegate()
 
-    LevelPlay.add(impressionDelegate as LPMImpressionDataDelegate)
-
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
         let requestBuilder = LPMInitRequestBuilder(appKey: kAppKey)
         let initRequest = requestBuilder.build()
@@ -25,6 +23,7 @@ func testShouldInitLoadShowRewardedAndReceiveImpression() async throws {
 
     let rewardedAd = LPMRewardedAd(adUnitId: kRewardedAdUnit)
     rewardedAd.setDelegate(delegate)
+    rewardedAd.setImpressionDataDelegate(impressionDelegate)
 
     // When
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in

--- a/iOS/Swift SPM/LevelPlayDemo.xcodeproj/project.pbxproj
+++ b/iOS/Swift SPM/LevelPlayDemo.xcodeproj/project.pbxproj
@@ -127,7 +127,7 @@
 			);
 			mainGroup = 471A2A321E66D27900217BE4;
 			packageReferences = (
-				10B802A62F34E51200F5C141 /* XCRemoteSwiftPackageReference "Unity-Mediation-iAds-Swift-Package" */,
+				10B802A62F34E51200F5C141 /* XCRemoteSwiftPackageReference "LevelPlay-Swift-Package" */,
 			);
 			productRefGroup = 471A2A3C1E66D27900217BE4 /* Products */;
 			projectDirPath = "";
@@ -372,12 +372,12 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		10B802A62F34E51200F5C141 /* XCRemoteSwiftPackageReference "Unity-Mediation-iAds-Swift-Package" */ = {
+		10B802A62F34E51200F5C141 /* XCRemoteSwiftPackageReference "LevelPlay-Swift-Package" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/ironsource-mobile/Unity-Mediation-iAds-Swift-Package";
+			repositoryURL = "https://github.com/ironsource-mobile/LevelPlay-Swift-Package";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 9.3.0;
+				minimumVersion = 9.5.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -385,7 +385,7 @@
 /* Begin XCSwiftPackageProductDependency section */
 		10B802A72F34E51200F5C141 /* UnityMediationSDK */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 10B802A62F34E51200F5C141 /* XCRemoteSwiftPackageReference "Unity-Mediation-iAds-Swift-Package" */;
+			package = 10B802A62F34E51200F5C141 /* XCRemoteSwiftPackageReference "LevelPlay-Swift-Package" */;
 			productName = UnityMediationSDK;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/iOS/Swift SPM/LevelPlayDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/Swift SPM/LevelPlayDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ironsource-mobile/Unity-Ad-Quality-Swift-Package",
       "state" : {
-        "revision" : "efff497b17657e81e8334084a4991f706d4407db",
-        "version" : "9.2.1"
+        "revision" : "bcbd7284d99d7570b8423b52d8ed7bd014215a40",
+        "version" : "9.8.0"
       }
     }
   ],

--- a/iOS/Swift SPM/LevelPlayDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/Swift SPM/LevelPlayDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "56a8f888ff286d87bad0a0051858a4d9d9cc197cc70ce11bad46510d4ea4bbf3",
+  "originHash" : "e116cc84e9e308c5fec852e2379253470d30ad209bf0dd9df1a442e8a2fa84c5",
   "pins" : [
+    {
+      "identity" : "levelplay-swift-package",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ironsource-mobile/LevelPlay-Swift-Package",
+      "state" : {
+        "revision" : "812a0d82c0664cedbed7084aa92ff4a7af92da0d",
+        "version" : "9.5.0"
+      }
+    },
     {
       "identity" : "unity-ad-quality-swift-package",
       "kind" : "remoteSourceControl",
@@ -8,15 +17,6 @@
       "state" : {
         "revision" : "efff497b17657e81e8334084a4991f706d4407db",
         "version" : "9.2.1"
-      }
-    },
-    {
-      "identity" : "unity-mediation-iads-swift-package",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ironsource-mobile/Unity-Mediation-iAds-Swift-Package",
-      "state" : {
-        "revision" : "e712d4a50618d14bf75776d0161dc2366515ca2b",
-        "version" : "9.3.0"
       }
     }
   ],

--- a/iOS/Swift SPM/LevelPlayDemo/DemoViewController.swift
+++ b/iOS/Swift SPM/LevelPlayDemo/DemoViewController.swift
@@ -42,21 +42,21 @@ class DemoViewController: UIViewController, DemoViewControllerDelegate {
     @IBOutlet weak var loadRewardedVideoButton: UIButton!
     @IBOutlet weak var showRewardedVideoButton: UIButton!
     var rewardedAdDelegate: DemoRewardedVideoAdDelegate! = nil
+    var rewardedImpressionDataDelegate: DemoImpressionDataDelegate! = nil
     var rewardedAd: LPMRewardedAd! = nil
     var reward: LPMReward! = nil
-
     
     @IBOutlet weak var loadInterstitialButton: UIButton!
     @IBOutlet weak var showInterstitialButton: UIButton!
     var interstitialAdDelegate: DemoInterstitialAdDelegate! = nil
+    var interstitialImpressionDataDelegate: DemoImpressionDataDelegate! = nil
     var interstitialAd: LPMInterstitialAd! = nil
 
     @IBOutlet weak var loadBannerButton: UIButton!
     var bannerAdViewDelegate: DemoBannerAdDelegate! = nil
+    var bannerImpressionDataDelegate: DemoImpressionDataDelegate! = nil
     var bannerAd: LPMBannerAdView! = nil
     var bannerSize: LPMAdSize! = nil
-
-    var impressionDataDelegate: DemoImpressionDataDelegate! = nil
 
     @IBOutlet weak var versionLabel: UILabel!
     
@@ -100,11 +100,6 @@ class DemoViewController: UIViewController, DemoViewControllerDelegate {
         LevelPlay.validateIntegration()
 #endif
         
-        
-        impressionDataDelegate = .init()
-        LevelPlay.add(self.impressionDataDelegate)
-        
-        // After setting the delegates you can go ahead and initialize the SDK.
         // Once the iniitaliztion callback is return you can start loading your ads
         
         self.logMethodName(string: "init levelPlay SDK with appKey:  \(appKey)")
@@ -133,6 +128,8 @@ class DemoViewController: UIViewController, DemoViewControllerDelegate {
         self.interstitialAd = LPMInterstitialAd(adUnitId: interstitialAdUnitId)
         interstitialAdDelegate = .init(delegate: self)
         self.interstitialAd.setDelegate(interstitialAdDelegate)
+        interstitialImpressionDataDelegate = .init()
+        self.interstitialAd.setImpressionDataDelegate(interstitialImpressionDataDelegate)
 
         self.setButtonEnablement(ButtonIdentifiers.loadInterstitialButtonIdentifier, enable: true)
     }
@@ -186,6 +183,8 @@ class DemoViewController: UIViewController, DemoViewControllerDelegate {
         // set the banner listener
         bannerAdViewDelegate = .init(delegate: self)
         self.bannerAd.setDelegate(bannerAdViewDelegate)
+        bannerImpressionDataDelegate = .init()
+        self.bannerAd.setImpressionDataDelegate(bannerImpressionDataDelegate)
         
         addBannerToView()
         
@@ -223,6 +222,8 @@ class DemoViewController: UIViewController, DemoViewControllerDelegate {
         self.rewardedAd = LPMRewardedAd(adUnitId: rewardedAdUnitId)
         rewardedAdDelegate = .init(delegate: self)
         self.rewardedAd.setDelegate(rewardedAdDelegate)
+        rewardedImpressionDataDelegate = .init()
+        self.rewardedAd.setImpressionDataDelegate(rewardedImpressionDataDelegate)
 
         self.setButtonEnablement(ButtonIdentifiers.loadRewardedVideoButtonIdentifier, enable: true)
     }

--- a/iOS/Swift/LevelPlayDemo/DemoViewController.swift
+++ b/iOS/Swift/LevelPlayDemo/DemoViewController.swift
@@ -102,7 +102,6 @@ class DemoViewController: UIViewController, DemoViewControllerDelegate {
         LevelPlay.validateIntegration()
 #endif
         
-        // After setting the delegates you can go ahead and initialize the SDK.
         // Once the iniitaliztion callback is return you can start loading your ads
         
         self.logMethodName(string: "init levelPlay SDK with appKey:  \(Self.appKey)")

--- a/iOS/Swift/LevelPlayDemo/DemoViewController.swift
+++ b/iOS/Swift/LevelPlayDemo/DemoViewController.swift
@@ -43,21 +43,22 @@ class DemoViewController: UIViewController, DemoViewControllerDelegate {
     @IBOutlet weak var loadRewardedVideoButton: UIButton!
     @IBOutlet weak var showRewardedVideoButton: UIButton!
     var rewardedAdDelegate: DemoRewardedVideoAdDelegate! = nil
+    var rewardedImpressionDataDelegate: DemoImpressionDataDelegate! = nil
     var rewardedAd: LPMRewardedAd! = nil
     var reward: LPMReward! = nil
 
-    
+
     @IBOutlet weak var loadInterstitialButton: UIButton!
     @IBOutlet weak var showInterstitialButton: UIButton!
     var interstitialAdDelegate: DemoInterstitialAdDelegate! = nil
+    var interstitialImpressionDataDelegate: DemoImpressionDataDelegate! = nil
     var interstitialAd: LPMInterstitialAd! = nil
 
     @IBOutlet weak var loadBannerButton: UIButton!
     var bannerAdViewDelegate: DemoBannerAdDelegate! = nil
+    var bannerImpressionDataDelegate: DemoImpressionDataDelegate! = nil
     var bannerAd: LPMBannerAdView! = nil
     var bannerSize: LPMAdSize! = nil
-
-    var impressionDataDelegate: DemoImpressionDataDelegate! = nil
 
     @IBOutlet weak var versionLabel: UILabel!
     
@@ -101,9 +102,6 @@ class DemoViewController: UIViewController, DemoViewControllerDelegate {
         LevelPlay.validateIntegration()
 #endif
         
-        impressionDataDelegate = .init()
-        LevelPlay.add(self.impressionDataDelegate)
-        
         // After setting the delegates you can go ahead and initialize the SDK.
         // Once the iniitaliztion callback is return you can start loading your ads
         
@@ -133,6 +131,8 @@ class DemoViewController: UIViewController, DemoViewControllerDelegate {
         self.interstitialAd = LPMInterstitialAd(adUnitId: Self.interstitialAdUnitId)
         interstitialAdDelegate = .init(delegate: self)
         self.interstitialAd.setDelegate(interstitialAdDelegate)
+        interstitialImpressionDataDelegate = .init()
+        self.interstitialAd.setImpressionDataDelegate(interstitialImpressionDataDelegate)
 
         self.setButtonEnablement(ButtonIdentifiers.loadInterstitialButtonIdentifier, enable: true)
     }
@@ -186,6 +186,8 @@ class DemoViewController: UIViewController, DemoViewControllerDelegate {
         // set the banner listener
         bannerAdViewDelegate = .init(delegate: self)
         self.bannerAd.setDelegate(bannerAdViewDelegate)
+        bannerImpressionDataDelegate = .init()
+        self.bannerAd.setImpressionDataDelegate(bannerImpressionDataDelegate)
         
         addBannerToView()
         
@@ -223,6 +225,8 @@ class DemoViewController: UIViewController, DemoViewControllerDelegate {
         self.rewardedAd = LPMRewardedAd(adUnitId: Self.rewardedAdUnitId)
         rewardedAdDelegate = .init(delegate: self)
         self.rewardedAd.setDelegate(rewardedAdDelegate)
+        rewardedImpressionDataDelegate = .init()
+        self.rewardedAd.setImpressionDataDelegate(rewardedImpressionDataDelegate)
 
         self.setButtonEnablement(ButtonIdentifiers.loadRewardedVideoButtonIdentifier, enable: true)
     }

--- a/iOS/Swift/LevelPlayDemoTests/BannerInitLoadAndImpressionIntegrationTest.swift
+++ b/iOS/Swift/LevelPlayDemoTests/BannerInitLoadAndImpressionIntegrationTest.swift
@@ -10,8 +10,6 @@ func testShouldInitLoadBannerAndReceiveImpression() async throws {
     let delegate = BannerTestDelegate()
     let impressionDelegate = BannerImpressionDelegate()
 
-    LevelPlay.add(impressionDelegate as LPMImpressionDataDelegate)
-
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
         let requestBuilder = LPMInitRequestBuilder(appKey: DemoViewController.appKey)
         let initRequest = requestBuilder.build()
@@ -27,6 +25,7 @@ func testShouldInitLoadBannerAndReceiveImpression() async throws {
     let config = LPMBannerAdViewConfigBuilder().set(adSize: .banner()).build()
     let bannerAd = LPMBannerAdView(adUnitId: DemoViewController.bannerAdUnitId, config: config)
     bannerAd.setDelegate(delegate)
+    bannerAd.setImpressionDataDelegate(impressionDelegate)
 
     let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
     let rootVC = windowScene?.windows.first(where: { $0.isKeyWindow })?.rootViewController

--- a/iOS/Swift/LevelPlayDemoTests/BannerInitLoadAndImpressionIntegrationTest.swift
+++ b/iOS/Swift/LevelPlayDemoTests/BannerInitLoadAndImpressionIntegrationTest.swift
@@ -3,23 +3,27 @@ import IronSource
 import UIKit
 @testable import LevelPlayDemo
 
-@Test(.timeLimit(.minutes(1)))
-@MainActor
-func testShouldInitLoadBannerAndReceiveImpression() async throws {
+@Suite(.serialized)
+struct AdIntegrationTests {}
+
+extension AdIntegrationTests {
+  @Test(.timeLimit(.minutes(1)))
+  @MainActor
+  func testShouldInitLoadBannerAndReceiveImpression() async throws {
     // Given
     let delegate = BannerTestDelegate()
     let impressionDelegate = BannerImpressionDelegate()
 
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-        let requestBuilder = LPMInitRequestBuilder(appKey: DemoViewController.appKey)
-        let initRequest = requestBuilder.build()
-        LevelPlay.initWith(initRequest) { config, error in
-            if let error = error {
-                continuation.resume(throwing: error)
-            } else {
-                continuation.resume()
-            }
+      let requestBuilder = LPMInitRequestBuilder(appKey: DemoViewController.appKey)
+      let initRequest = requestBuilder.build()
+      LevelPlay.initWith(initRequest) { config, error in
+        if let error = error {
+          continuation.resume(throwing: error)
+        } else {
+          continuation.resume()
         }
+      }
     }
 
     let config = LPMBannerAdViewConfigBuilder().set(adSize: .banner()).build()
@@ -33,32 +37,33 @@ func testShouldInitLoadBannerAndReceiveImpression() async throws {
     bannerAd.translatesAutoresizingMaskIntoConstraints = false
     rootVC!.view.addSubview(bannerAd)
     NSLayoutConstraint.activate([
-        bannerAd.centerXAnchor.constraint(equalTo: rootVC!.view.centerXAnchor),
-        bannerAd.bottomAnchor.constraint(equalTo: rootVC!.view.safeAreaLayoutGuide.bottomAnchor),
-        bannerAd.widthAnchor.constraint(equalToConstant: 320),
-        bannerAd.heightAnchor.constraint(equalToConstant: 50)
+      bannerAd.centerXAnchor.constraint(equalTo: rootVC!.view.centerXAnchor),
+      bannerAd.bottomAnchor.constraint(equalTo: rootVC!.view.safeAreaLayoutGuide.bottomAnchor),
+      bannerAd.widthAnchor.constraint(equalToConstant: 320),
+      bannerAd.heightAnchor.constraint(equalToConstant: 50)
     ])
 
     // When
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-        delegate.onLoad = { continuation.resume() }
-        delegate.onLoadFail = { error in continuation.resume(throwing: error) }
-        bannerAd.loadAd(with: rootVC!)
+      delegate.onLoad = { continuation.resume() }
+      delegate.onLoadFail = { error in continuation.resume(throwing: error) }
+      bannerAd.loadAd(with: rootVC!)
     }
 
     // Then
     if !impressionDelegate.received {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            if impressionDelegate.received {
-                continuation.resume()
-            } else {
-                impressionDelegate.onImpression = { continuation.resume() }
-            }
+      try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+        if impressionDelegate.received {
+          continuation.resume()
+        } else {
+          impressionDelegate.onImpression = { continuation.resume() }
         }
+      }
     }
 
     bannerAd.removeFromSuperview()
     bannerAd.destroy()
+  }
 }
 
 private class BannerTestDelegate: NSObject, LPMBannerAdViewDelegate {

--- a/iOS/Swift/LevelPlayDemoTests/InterstitialInitLoadShowAndImpressionIntegrationTest.swift
+++ b/iOS/Swift/LevelPlayDemoTests/InterstitialInitLoadShowAndImpressionIntegrationTest.swift
@@ -10,8 +10,6 @@ func testShouldInitLoadShowInterstitialAndReceiveImpression() async throws {
     let delegate = InterstitialTestDelegate()
     let impressionDelegate = TestImpressionDelegate()
 
-    LevelPlay.add(impressionDelegate as LPMImpressionDataDelegate)
-
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
         let requestBuilder = LPMInitRequestBuilder(appKey: DemoViewController.appKey)
         let initRequest = requestBuilder.build()
@@ -26,6 +24,7 @@ func testShouldInitLoadShowInterstitialAndReceiveImpression() async throws {
 
     let interstitialAd = LPMInterstitialAd(adUnitId: DemoViewController.interstitialAdUnitId)
     interstitialAd.setDelegate(delegate)
+    interstitialAd.setImpressionDataDelegate(impressionDelegate)
 
     // When
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in

--- a/iOS/Swift/LevelPlayDemoTests/InterstitialInitLoadShowAndImpressionIntegrationTest.swift
+++ b/iOS/Swift/LevelPlayDemoTests/InterstitialInitLoadShowAndImpressionIntegrationTest.swift
@@ -3,23 +3,24 @@ import IronSource
 import UIKit
 @testable import LevelPlayDemo
 
-@Test(.timeLimit(.minutes(1)))
-@MainActor
-func testShouldInitLoadShowInterstitialAndReceiveImpression() async throws {
+extension AdIntegrationTests {
+  @Test(.timeLimit(.minutes(1)))
+  @MainActor
+  func testShouldInitLoadShowInterstitialAndReceiveImpression() async throws {
     // Given
     let delegate = InterstitialTestDelegate()
     let impressionDelegate = TestImpressionDelegate()
 
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-        let requestBuilder = LPMInitRequestBuilder(appKey: DemoViewController.appKey)
-        let initRequest = requestBuilder.build()
-        LevelPlay.initWith(initRequest) { config, error in
-            if let error = error {
-                continuation.resume(throwing: error)
-            } else {
-                continuation.resume()
-            }
+      let requestBuilder = LPMInitRequestBuilder(appKey: DemoViewController.appKey)
+      let initRequest = requestBuilder.build()
+      LevelPlay.initWith(initRequest) { config, error in
+        if let error = error {
+          continuation.resume(throwing: error)
+        } else {
+          continuation.resume()
         }
+      }
     }
 
     let interstitialAd = LPMInterstitialAd(adUnitId: DemoViewController.interstitialAdUnitId)
@@ -28,9 +29,9 @@ func testShouldInitLoadShowInterstitialAndReceiveImpression() async throws {
 
     // When
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-        delegate.onLoad = { continuation.resume() }
-        delegate.onLoadFail = { error in continuation.resume(throwing: error) }
-        interstitialAd.loadAd()
+      delegate.onLoad = { continuation.resume() }
+      delegate.onLoadFail = { error in continuation.resume(throwing: error) }
+      interstitialAd.loadAd()
     }
 
     let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
@@ -40,26 +41,34 @@ func testShouldInitLoadShowInterstitialAndReceiveImpression() async throws {
 
     // Then
     if !impressionDelegate.received {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            if impressionDelegate.received {
-                continuation.resume()
-            } else {
-                impressionDelegate.onImpression = { continuation.resume() }
-            }
+      try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+        if impressionDelegate.received {
+          continuation.resume()
+        } else {
+          impressionDelegate.onImpression = { continuation.resume() }
         }
+      }
     }
+
+    // Cleanup: dismiss the fullscreen ad so a subsequent test can present one
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      delegate.onClose = { continuation.resume() }
+      rootVC?.dismiss(animated: false)
+    }
+  }
 }
 
 private class InterstitialTestDelegate: NSObject, LPMInterstitialAdDelegate {
     var onLoad: (() -> Void)?
     var onLoadFail: ((Error) -> Void)?
+    var onClose: (() -> Void)?
 
     func didLoadAd(with adInfo: LPMAdInfo) { onLoad?() }
     func didFailToLoadAd(withAdUnitId adUnitId: String, error: Error) { onLoadFail?(error) }
     func didDisplayAd(with adInfo: LPMAdInfo) {}
     func didFailToDisplayAd(with adInfo: LPMAdInfo, error: Error) {}
     func didClickAd(with adInfo: LPMAdInfo) {}
-    func didCloseAd(with adInfo: LPMAdInfo) {}
+    func didCloseAd(with adInfo: LPMAdInfo) { onClose?() }
     func didChangeAdInfo(_ adInfo: LPMAdInfo) {}
 }
 

--- a/iOS/Swift/LevelPlayDemoTests/RewardedInitLoadShowAndImpressionIntegrationTest.swift
+++ b/iOS/Swift/LevelPlayDemoTests/RewardedInitLoadShowAndImpressionIntegrationTest.swift
@@ -3,23 +3,24 @@ import IronSource
 import UIKit
 @testable import LevelPlayDemo
 
-@Test(.timeLimit(.minutes(1)))
-@MainActor
-func testShouldInitLoadShowRewardedAndReceiveImpression() async throws {
+extension AdIntegrationTests {
+  @Test(.timeLimit(.minutes(1)))
+  @MainActor
+  func testShouldInitLoadShowRewardedAndReceiveImpression() async throws {
     // Given
     let delegate = RewardedTestDelegate()
     let impressionDelegate = RewardedImpressionDelegate()
 
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-        let requestBuilder = LPMInitRequestBuilder(appKey: DemoViewController.appKey)
-        let initRequest = requestBuilder.build()
-        LevelPlay.initWith(initRequest) { config, error in
-            if let error = error {
-                continuation.resume(throwing: error)
-            } else {
-                continuation.resume()
-            }
+      let requestBuilder = LPMInitRequestBuilder(appKey: DemoViewController.appKey)
+      let initRequest = requestBuilder.build()
+      LevelPlay.initWith(initRequest) { config, error in
+        if let error = error {
+          continuation.resume(throwing: error)
+        } else {
+          continuation.resume()
         }
+      }
     }
 
     let rewardedAd = LPMRewardedAd(adUnitId: DemoViewController.rewardedAdUnitId)
@@ -28,9 +29,9 @@ func testShouldInitLoadShowRewardedAndReceiveImpression() async throws {
 
     // When
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-        delegate.onLoad = { continuation.resume() }
-        delegate.onLoadFail = { error in continuation.resume(throwing: error) }
-        rewardedAd.loadAd()
+      delegate.onLoad = { continuation.resume() }
+      delegate.onLoadFail = { error in continuation.resume(throwing: error) }
+      rewardedAd.loadAd()
     }
 
     let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
@@ -40,26 +41,34 @@ func testShouldInitLoadShowRewardedAndReceiveImpression() async throws {
 
     // Then
     if !impressionDelegate.received {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            if impressionDelegate.received {
-                continuation.resume()
-            } else {
-                impressionDelegate.onImpression = { continuation.resume() }
-            }
+      try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+        if impressionDelegate.received {
+          continuation.resume()
+        } else {
+          impressionDelegate.onImpression = { continuation.resume() }
         }
+      }
     }
+
+    // Cleanup: dismiss the fullscreen ad so a subsequent test can present one
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      delegate.onClose = { continuation.resume() }
+      rootVC?.dismiss(animated: false)
+    }
+  }
 }
 
 private class RewardedTestDelegate: NSObject, LPMRewardedAdDelegate {
     var onLoad: (() -> Void)?
     var onLoadFail: ((Error) -> Void)?
+    var onClose: (() -> Void)?
 
     func didLoadAd(with adInfo: LPMAdInfo) { onLoad?() }
     func didFailToLoadAd(withAdUnitId adUnitId: String, error: Error) { onLoadFail?(error) }
     func didDisplayAd(with adInfo: LPMAdInfo) {}
     func didFailToDisplayAd(with adInfo: LPMAdInfo, error: Error) {}
     func didClickAd(with adInfo: LPMAdInfo) {}
-    func didCloseAd(with adInfo: LPMAdInfo) {}
+    func didCloseAd(with adInfo: LPMAdInfo) { onClose?() }
     func didRewardAd(with adInfo: LPMAdInfo, reward: LPMReward) {}
     func didChangeAdInfo(_ adInfo: LPMAdInfo) {}
 }

--- a/iOS/Swift/LevelPlayDemoTests/RewardedInitLoadShowAndImpressionIntegrationTest.swift
+++ b/iOS/Swift/LevelPlayDemoTests/RewardedInitLoadShowAndImpressionIntegrationTest.swift
@@ -10,8 +10,6 @@ func testShouldInitLoadShowRewardedAndReceiveImpression() async throws {
     let delegate = RewardedTestDelegate()
     let impressionDelegate = RewardedImpressionDelegate()
 
-    LevelPlay.add(impressionDelegate as LPMImpressionDataDelegate)
-
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
         let requestBuilder = LPMInitRequestBuilder(appKey: DemoViewController.appKey)
         let initRequest = requestBuilder.build()
@@ -26,6 +24,7 @@ func testShouldInitLoadShowRewardedAndReceiveImpression() async throws {
 
     let rewardedAd = LPMRewardedAd(adUnitId: DemoViewController.rewardedAdUnitId)
     rewardedAd.setDelegate(delegate)
+    rewardedAd.setImpressionDataDelegate(impressionDelegate)
 
     // When
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in


### PR DESCRIPTION
## Summary

### Impression data listener
The app-level impression data listener is **deprecated** in LevelPlay 9.5.0. Publishers
should now register the listener/delegate **on each ad unit** instead of globally. This PR
updates every demo app to showcase the replacement API so integrators copy the current,
non-deprecated pattern.

- **Android:** `LevelPlay.addImpressionDataListener(...)` → `adUnit.setImpressionDataListener(...)`
- **iOS:** `[LevelPlay addImpressionDataDelegate:]` / `LevelPlay.add(...)` →
  `adUnit.setImpressionDataDelegate(...)`

### Swift SPM package update
- Swapped the SDK dependency from **`Unity-Mediation-iAds-Swift-Package` (9.3.0)** to
  **`LevelPlay-Swift-Package` (9.5.0)**.