### PR TITLE
Parameterize compileSdk / targetSdk for target-SDK regression checks

### DIFF
--- a/.github/workflows/build-android-kotlin-with-sdk-version.yml
+++ b/.github/workflows/build-android-kotlin-with-sdk-version.yml
@@ -1,4 +1,4 @@
-name: Build Android Kotlin with Custom SDK Version
+name: Build Android Demo Apps with Custom SDK Version
 
 on:
   workflow_dispatch:
@@ -7,10 +7,18 @@ on:
         description: 'LevelPlay SDK version'
         required: true
         type: string
+      target_sdk_version:
+        description: 'Android target + compiled SDK version'
+        required: false
+        type: string
+        default: '34'
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project: [Kotlin, Java]
 
     env:
       PRIVATE_MAVEN_USERNAME: ${{ secrets.PRIVATE_MAVEN_USERNAME }}
@@ -18,7 +26,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: Android/Kotlin
+        working-directory: Android/${{ matrix.project }}
 
     steps:
       - name: Checkout code
@@ -43,25 +51,61 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build Debug APK
-        run: ./gradlew assembleDebug -PsdkVersion=${{ inputs.sdk_version }} --stacktrace
+        run: |
+          ./gradlew assembleDebug \
+            -PsdkVersion=${{ inputs.sdk_version }} \
+            -PtargetSdkVersion=${{ inputs.target_sdk_version }} \
+            -PcompileSdkVersion=${{ inputs.target_sdk_version }} \
+            --stacktrace
+
+      - name: Verify resolved SDK versions
+        run: |
+          {
+            echo "### ${{ matrix.project }} SDK version verification"
+            echo ""
+            echo "**Passed to Gradle:**"
+            echo "- \`-PtargetSdkVersion=${{ inputs.target_sdk_version }}\`"
+            echo "- \`-PcompileSdkVersion=${{ inputs.target_sdk_version }}\`"
+            echo ""
+            echo "**Resolved Gradle ext values:**"
+            echo '```'
+            ./gradlew :app:properties -q \
+              -PsdkVersion=${{ inputs.sdk_version }} \
+              -PtargetSdkVersion=${{ inputs.target_sdk_version }} \
+              -PcompileSdkVersion=${{ inputs.target_sdk_version }} \
+              | grep -E "^(demoCompileSdk|demoTargetSdk|sdkVersion):" | head -3
+            echo '```'
+            echo ""
+            echo "**APK manifest (aapt2 dump badging):**"
+            echo '```'
+            BUILD_TOOLS=$(ls -d $ANDROID_HOME/build-tools/*/ | sort -V | tail -1)
+            ${BUILD_TOOLS}aapt2 dump badging app/build/outputs/apk/debug/app-debug.apk \
+              | grep -E "^(sdkVersion|targetSdkVersion|application:)"
+            echo '```'
+          } >> $GITHUB_STEP_SUMMARY
 
       - name: Build Release APK
-        run: ./gradlew assembleRelease -PsdkVersion=${{ inputs.sdk_version }} --stacktrace
+        run: |
+          ./gradlew assembleRelease \
+            -PsdkVersion=${{ inputs.sdk_version }} \
+            -PtargetSdkVersion=${{ inputs.target_sdk_version }} \
+            -PcompileSdkVersion=${{ inputs.target_sdk_version }} \
+            --stacktrace
 
       - name: Upload APK Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: apk-sdk-${{ inputs.sdk_version }}
+          name: apk-${{ matrix.project }}-sdk-${{ inputs.sdk_version }}-target-${{ inputs.target_sdk_version }}
           path: |
-            Android/Kotlin/app/build/outputs/apk/debug/app-debug.apk
-            Android/Kotlin/app/build/outputs/apk/release/app-release-unsigned.apk
+            Android/${{ matrix.project }}/app/build/outputs/apk/debug/app-debug.apk
+            Android/${{ matrix.project }}/app/build/outputs/apk/release/app-release-unsigned.apk
           retention-days: 30
 
       - name: Upload Build Reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: build-reports-sdk-${{ inputs.sdk_version }}
+          name: build-reports-${{ matrix.project }}-sdk-${{ inputs.sdk_version }}-target-${{ inputs.target_sdk_version }}
           path: |
-            Android/Kotlin/app/build/reports/
+            Android/${{ matrix.project }}/app/build/reports/
           retention-days: 7

--- a/Android/Java/app/build.gradle
+++ b/Android/Java/app/build.gradle
@@ -1,13 +1,19 @@
 apply plugin: 'com.android.application'
 
+ext {
+    sdkVersion = project.hasProperty('sdkVersion') ? project.property('sdkVersion') : "9.+"
+    demoCompileSdk = project.hasProperty('compileSdkVersion') ? project.property('compileSdkVersion').toInteger() : 34
+    demoTargetSdk = project.hasProperty('targetSdkVersion') ? project.property('targetSdkVersion').toInteger() : 34
+}
+
 android {
     namespace "com.unity3d.levelplaydemo"
-    compileSdkVersion 34
+    compileSdkVersion demoCompileSdk
     buildToolsVersion '34.0.0'
     defaultConfig {
         applicationId "com.unity3d.levelplaydemo"
         minSdkVersion 19
-        targetSdkVersion 34
+        targetSdkVersion demoTargetSdk
         versionCode 1
         versionName "1.0"
         multiDexEnabled = true
@@ -38,7 +44,7 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.cardview:cardview:1.0.0'
     // Add LevelPlay Mediation SDK dependency.
-    implementation "com.unity3d.ads-mediation:mediation-sdk:9.+"
+    implementation "com.unity3d.ads-mediation:mediation-sdk:$sdkVersion"
     implementation "com.unity3d.ads-mediation:unityads-adapter:5.+"
     implementation "com.unity3d.ads:unity-ads:4.+"
 

--- a/Android/Kotlin/app/build.gradle
+++ b/Android/Kotlin/app/build.gradle
@@ -5,16 +5,18 @@ plugins {
 
 ext {
     sdkVersion = project.hasProperty('sdkVersion') ? project.property('sdkVersion') : "9.+"
+    demoCompileSdk = project.hasProperty('compileSdkVersion') ? project.property('compileSdkVersion').toInteger() : 34
+    demoTargetSdk = project.hasProperty('targetSdkVersion') ? project.property('targetSdkVersion').toInteger() : 34
 }
 
 android {
     namespace "com.unity3d.levelplaydemo"
-    compileSdkVersion 34
+    compileSdkVersion demoCompileSdk
     buildToolsVersion '34.0.0'
     defaultConfig {
         applicationId "com.unity3d.levelplaydemo"
         minSdkVersion 19
-        targetSdkVersion 34
+        targetSdkVersion demoTargetSdk
         versionCode 1
         versionName "1.0"
         multiDexEnabled true


### PR DESCRIPTION
## Summary

Enables building the Android demo apps against any `compileSdkVersion` / `targetSdkVersion`, so the LP Android SDK's OS-readiness process can verify that a new Android target SDK doesn't break the demo build against the current production LevelPlay SDK.

Both Kotlin and Java demos now accept two new Gradle properties, and the `workflow_dispatch` workflow that builds them takes a matching optional input.

## Changes

- **`Android/Kotlin/app/build.gradle`** — adds `demoCompileSdk` / `demoTargetSdk` to the existing `ext {}` block, driven by `-PcompileSdkVersion` / `-PtargetSdkVersion` (defaults `34`).
- **`Android/Java/app/build.gradle`** — adds a new `ext {}` block with `sdkVersion` + `demoCompileSdk` + `demoTargetSdk`, and switches the LP SDK dependency from `mediation-sdk:9.+` to `mediation-sdk:\$sdkVersion` for parity with Kotlin.
- **`.github/workflows/build-android-kotlin-with-sdk-version.yml`**:
  - Renamed display: `Build Android Demo Apps with Custom SDK Version` (file name preserved for backward compat).
  - Adds optional `target_sdk_version` input (default `34`, applied to both compile and target).
  - Adds matrix `[Kotlin, Java]` — one job per project.
  - Adds a **Verify resolved SDK versions** step that emits, to the run summary, (a) the values passed to Gradle, (b) the resolved `demoCompileSdk` / `demoTargetSdk` / `sdkVersion` from `./gradlew :app:properties`, and (c) the final APK manifest values via `aapt2 dump badging`. Three independent proofs that the input flowed through to the artifact.
  - Artifact names updated to include project + target.

## Backward compatibility

- Existing invocations passing only `sdk_version` → `target_sdk_version` defaults to `'34'` → gradle receives `-PtargetSdkVersion=34` and `-PcompileSdkVersion=34` → same behavior as before the change.
- File name of the workflow unchanged, so any `gh workflow run build-android-kotlin-with-sdk-version.yml` scripts keep working.
- Kotlin-side `sdkVersion` behavior unchanged (already parameterized). Java-side now also honors `-PsdkVersion` (was hardcoded `9.+`).

## Verification

Test run against this branch on 2026-07-21 with `sdk_version=9.5.0`, `target_sdk_version=35`: both Kotlin and Java jobs green, verification step confirmed `targetSdkVersion:'35'` in both APK manifests. Run: https://github.com/ironsource-mobile/Mediation-Demo-Apps/actions/runs/29843066584

## Follow-ups (not in this PR)

- AGP 8.2.2 emits a "tested up to compileSdk = 34" warning when building with 35. The warning is non-fatal at 35 but may become a build error at compileSdk 37 (Android 17). Bump the root `build.gradle` AGP version if/when target 37 actually fails to build.

## Test plan

- [x] Kotlin job builds with `target_sdk_version=35` and produces an APK whose manifest reports `targetSdkVersion:'35'`
- [x] Java job builds with `target_sdk_version=35` and produces an APK whose manifest reports `targetSdkVersion:'35'`
- [ ] Kotlin + Java build with default (no `target_sdk_version` input) → matches pre-PR behavior
- [ ] Kotlin + Java build with `target_sdk_version=37` — expected to fail today on AGP 8.2.2 (which is why the follow-up above exists)

Related: LP Android SDK OS-readiness tracker ticket NS-11442 (Android 17 research pass).